### PR TITLE
Fixed typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The most important controls are displayed on screen, here is a list of all:
 Most features require the user to choose a file or a directory. In these cases, use the arrow keys to select and A / B to confirm and cancel.
 
 ## License
-You may use this under the terms of the GNE General Public License GPL v2 or under the terms of any later revisions of the GPL. Refer to the provided `LICENSE.txt` file for further information.
+You may use this under the terms of the GNU General Public License GPL v2 or under the terms of any later revisions of the GPL. Refer to the provided `LICENSE.txt` file for further information.
 
 ## Credits
 * smealum, plutoo, derrek for giving the world the gift of arm9loaderhax


### PR DESCRIPTION
The same typo is in the Decrypt9 README.md, so that should be fixed there also.
